### PR TITLE
fix: [doc] absolute link from Tutorials -> Software

### DIFF
--- a/docs/tutorials.md
+++ b/docs/tutorials.md
@@ -8,7 +8,7 @@ permalink: /tutorials/
 
 ---
 
-Some tutorials are associated with software on the [software](software) page.
+Some tutorials are associated with software on the [software](/software) page.
 
 This page contains hyperlinks to tutorials that have been generated, tested
 and are maintained by the Open SIMH community.

--- a/docs/tutorials.md
+++ b/docs/tutorials.md
@@ -8,7 +8,7 @@ permalink: /tutorials/
 
 ---
 
-Some tutorials are associated with sofware on the [software](software) page.
+Some tutorials are associated with software on the [software](software) page.
 
 This page contains hyperlinks to tutorials that have been generated, tested
 and are maintained by the Open SIMH community.


### PR DESCRIPTION
Related to #5 - when visiting the https://opensimh.org/tutorials/ page, there is a broken link to https://opensimh.org/tutorials/software. I think the intended link is to https://opensimh.org/software/

If I understand the Jekyll documentation correctly for GitHub Pages, the link is a relative link by default. We don't want that, as it renders into the unwanted `/tutorials/software` path instead of intended `/software`. However, I am unfamiliar with how to test with GH Pages, so this change is untested. Can you kindly test or suggest how to test?

- fix: [doc] use absolute link to avoid unwanted subfolder
- fix: minor typo in tutorials.md